### PR TITLE
Allows non-existent platforms

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { checkForRootFiles } from "./checks/folders"
 import { Reporter } from "./report"
 import {
   checkAllMentionedFilesExist,
-  checkAllSpecifiedPlatformsExist,
+  checkSpecifiedPlatformsExist,
   checkCoreFolderName,
   checkForSemver,
   checkCoreJSONSchema,
@@ -62,7 +62,7 @@ export const processZip = async (
   await checkCoreJSONSchema(zip, reporter)
   await countCoresInZip(zip, reporter)
   await checkForSemver(zip, reporter)
-  await checkAllSpecifiedPlatformsExist(zip, reporter)
+  await checkSpecifiedPlatformsExist(zip, reporter)
 
   // input
 

--- a/src/schemas/instance_json.ts
+++ b/src/schemas/instance_json.ts
@@ -25,7 +25,7 @@ export const instanceJsonSchema = z.strictObject({
       .optional(),
     data_slots: z
       .array(
-        z.strictObject({
+        z.object({
           id: intOrHexSchema({ bits: 16, signed: false }),
           filename: z.string().max(255),
         })


### PR DESCRIPTION
- The analogue docs said `should` & `can` so I've avoided the outright error
- I've left in an error if there's no actual platforms at all, which is contrary to the Analogue docs but a 0 platform core will cause all the updates & the inventory problems (and probably not be selectable from the OpenFPGA menu on the Pocket) 